### PR TITLE
Introduces Debian-13 GMI

### DIFF
--- a/etc/cloud/Debian/13/seed-data/meta-data
+++ b/etc/cloud/Debian/13/seed-data/meta-data
@@ -1,0 +1,2 @@
+instance-id: {{ INSTANCE }}
+local-hostname: {{ HOSTNAME }}

--- a/etc/cloud/Debian/13/seed-data/network-config
+++ b/etc/cloud/Debian/13/seed-data/network-config
@@ -1,0 +1,4 @@
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true

--- a/etc/cloud/Debian/13/seed-data/user-data
+++ b/etc/cloud/Debian/13/seed-data/user-data
@@ -1,0 +1,20 @@
+#cloud-config
+users:
+  - default
+  - name: {{ USERNAME }}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+    home: /home/{{ USERNAME }}
+    lock_passwd: true
+    groups: sudo
+    ssh-authorized-keys:
+      - {{ PRIVKEY }}
+ssh_pwauth: false
+disable_root: true
+timezone: {{ TIMEZONE }}
+locale: {{ LOCALE }}
+keyboard:
+  layout: {{ LAYOUT }}
+runcmd:
+  - apt update -y
+  - apt upgrade -y

--- a/gmi-repository.dist.yml
+++ b/gmi-repository.dist.yml
@@ -10,6 +10,18 @@ Debian-12:
     description: "The official vmgenie Debian 12 image."
     hyperv_generation: 2
 
+Debian-13:
+  - name: "GMI Debian 13"
+    version: "13"
+    url: "https://vmgenie-gmi.s3.us-east-2.amazonaws.com/GMI-Debian-13.zip"
+    crc64nvme: "Gk0+QmfBXCQ="
+    last_modified: "2025-08-12T18:04:10+00:00"
+    maintainer: "Jesse Greathouse"
+    maintainer_email: "jesse.greathouse@gmail.com"
+    source_url: "https://github.com/jesse-greathouse/vmgenie"
+    description: "The official vmgenie Debian 13 image."
+    hyperv_generation: 2
+
 Fedora-40:
   - name: "GMI Fedora 40"
     version: "40"


### PR DESCRIPTION
> Adding a new GMI catalog entry in gmi-repository.dist.yml

* Changes
    * gmi-repository.dist.yml * Added `Debian-13` section with: * name: "GMI Debian 13" * version: "13" * url: "https://vmgenie-gmi.s3.us-east-2.amazonaws.com/GMI-Debian-13.zip" * crc64nvme: "Gk0+QmfBXCQ=" * last_modified: "2025-08-12T18:04:10+00:00" * maintainer: "Jesse Greathouse" * maintainer_email: "jesse.greathouse@gmail.com" * source_url: "https://github.com/jesse-greathouse/vmgenie" * description: "The official vmgenie Debian 13 image." * hyperv_generation: 2
    * etc/cloud/Debian/13/
        * new file: seed-data/meta-data
        * new file: seed-data/network-config * new file: seed-data/user-data